### PR TITLE
Fixed md5, echo and regex. Added current date to file and make password choosable.

### DIFF
--- a/README
+++ b/README
@@ -4,15 +4,16 @@ fritzbox-config-downloader
 Downloads a configuration backup of an AVM Fritz!Box to the local file Fritzbox.export.
 Originally developed for automatic backups with rsnapshot.
 It supports downloading the condig through the internet with the function Fernzugriff.
-The configuration is ecrypted with password "admin". Without a password you cannot
+The configuration is ecrypted with a password of your choice or "admin" as default. Without a password you cannot
 load the config into another Fritzbox.
 
-Usage: ./fritzbox-config-downloader [Hostname[:Port] [Password [Username [Fernzugriff [SecondPassword]]]]]
+Usage: ./fritzbox-config-downloader [Hostname[:Port] [Password [Username [ExportPassword [Fernzugriff [SecondPassword]]]]]]
 
 Hostname[:Port]		Hostname or IP of the Fritzbox to backup. Portnumber is optional.
 			Default is "fritz.box"
 Password		Password of the Fritzbox.
 Username		Username for newer Fritzbox or Fernzugriff
+ExportPassword	Password for the backup file. Default is "admin"
 Fernzugriff		Set to 1 to connect to a Fritzbox via Fernzugriff through the
 			internet (uses for example https)
 SecondPassword		Older Boxes secure Fernzugriff with HTTP-Auth. If the box has

--- a/fritzbox-config-downloader
+++ b/fritzbox-config-downloader
@@ -2,11 +2,12 @@
 Host=${1:-fritz.box}
 Password=${2}
 Username=${3}
-Fernzugriff=${4:-0}
-SecondPassword=${5}
+ExportPassword=${4:-admin}
+Fernzugriff=${5:-0}
+SecondPassword=${6}
 
-ExportPassword="admin"
-ExportFilename="Fritzbox.export"
+Now=$(date +"%Y%m%d%H%M%S")
+ExportFilename="FritzBox_${Now}.export"
 
 CURL="curl -ksm 20"
 # Fuer den Fernzugriff HTTPs und HTTP Auth verwenden
@@ -54,7 +55,7 @@ elif [ "${SID}" = "0000000000000000" ]; then
 		echo "${Login}"
 		exit 2
 	fi
-	Response=$(echo -n "${Challenge}-${Password}" | iconv -f utf-8 -t utf-16le | md5sum -b | sed "s| .*||g")
+	Response=$(printf "${Challenge}-${Password}" | iconv -f utf-8 -t utf-16le | md5 | sed "s| .*||g")
 
 
 	case "${LoginType}" in
@@ -81,11 +82,11 @@ if [ "$?" != "0" ]; then
 	echo "Download des Backups von Fritzbox ${Host} fehlgeschlagen"
 	rm -f "${ExportFilename}"
 	exit 2
-elif ! head -n 1 "${ExportFilename}" | grep -q "^**** FRITZ!Box .* CONFIGURATION EXPORT$"; then
+elif ! head -n 1 "${ExportFilename}" | grep -q "^\*\*\*\* FRITZ!Box .* CONFIGURATION EXPORT$"; then
 	echo "Download ist kein Backup einer Fritzbox?!"
 	rm "${ExportFilename}"
 	exit 2
-elif ! tail -n 1 "${ExportFilename}" | grep -q "^**** END OF EXPORT .* ****$"; then
+elif ! tail -n 1 "${ExportFilename}" | grep -q "^\*\*\*\* END OF EXPORT .* \*\*\*\*$"; then
 	echo "Download ist unvollstaendig"
 	rm "${ExportFilename}"
 	exit 4


### PR DESCRIPTION
- `md5sum` no longer exists (or is not installed by default at least). Changed it to `md5`.
- `echo -n` is not really nice. `printf` works more reliable on every machine.
- the regex at the end for checking if the file is complete was wrong (\* is a modifier character and has to be escaped)
- added the current date to the file name make a history of files possible
- added an argument for choosing the password of the export file
